### PR TITLE
Add PR and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,11 @@
+---
+name: Bug Report
+about: Report a problem with this project
+title: ''
+labels: bug
+assignees: ''
+---
+<!--
+Tell us about the problem you encountered.
+If possible, include a short, self-contained, correct example (https://sscce.org/).
+-->

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,0 +1,10 @@
+---
+name: Documentation Issue
+about: Report a problem with the documentation for this project
+title: ''
+labels: documentation
+assignees: ''
+---
+<!--
+If there is a specific part of the documentation that is incorrect or unclear, please quote or link it so that we know exactly which part you are referring to.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Request a new feature
+title: ''
+labels: enhancement
+assignees: ''
+---
+<!--
+Tell us about the use case that you hope to solve.
+Try to avoid the XY Problem (https://xyproblem.info/) so that we can fully understand your requirements.
+If you have a specific feature in mind that you think will solve it, tell us about that too in as little or as much detail as you like.
+-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Ask a question about this project
+title: ''
+labels: question
+assignees: ''
+---
+<!--
+Ask a question about how something works, how to use this project, or anything else related to this project.
+Be mindful of the XY Problem (https://xyproblem.info/) so that we can best help you.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### Issue #, if available:
+
+### Description of changes:
+
+----
+_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-## My Project
+## amazon-ion/.github
 
-TODO: Fill this README out!
-
-Be sure to:
-
-* Change the title in this README
-* Edit your repository description on GitHub
+This repository contains default community health files for the `amazon-ion` GitHub organization.
 
 ## Security
 


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

Adds default PR and Issue templates for the `amazon-ion` GitHub organization. Any repos in this organization that do not define their own PR template or issue template will use these ones.

You can see these issue templates in action at [popematt/.github](https://github.com/popematt/.github/issues/new/choose).



__*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*__







