### PR TITLE
Add README for GitHub Organization profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,36 @@
+# Amazon Ion
+
+## 🚧 Under Construction 🚧
+
+Please pardon our mess.
+We're in the middle of migrating Amazon Ion projects from [github.com/amzn](https://www.github.com/amzn) to [github.com/amazon-ion](https://www.github.com/amazon-ion).
+
+## Projects
+
+* [ion-c](https://www.github.com/amzn/ion-c)
+* [ion-cli](https://www.github.com/amzn/ion-cli)
+* [ion-docs](https://www.github.com/amzn/ion-docs)
+* [ion-dotnet](https://www.github.com/amzn/ion-dotnet)
+* [ion-eclipse-plugin](https://www.github.com/amzn/ion-eclipse-plugin)
+* [ion-element-kotlin](https://www.github.com/amzn/ion-element-kotlin)
+* [ion-go](https://www.github.com/amzn/ion-go)
+* [ion-hash](https://www.github.com/amzn/ion-hash)
+* [ion-hash-dotnet](https://www.github.com/amzn/ion-hash-dotnet)
+* [ion-hash-go](https://www.github.com/amzn/ion-hash-go)
+* [ion-hash-java](https://www.github.com/amzn/ion-hash-java)
+* [ion-hash-js](https://www.github.com/amzn/ion-hash-js)
+* [ion-hash-python](https://www.github.com/amzn/ion-hash-python)
+* [ion-hash-test](https://www.github.com/amzn/ion-hash-test)
+* [ion-hash-test-driver](https://www.github.com/amzn/ion-hash-test-driver)
+* [ion-hive-serde](https://www.github.com/amzn/ion-hive-serde)
+* [ion-intellij-plugin](https://www.github.com/amzn/ion-intellij-plugin)
+* [ion-java](https://www.github.com/amzn/ion-java)
+* [ion-java-benchmark-cli](https://www.github.com/amzn/ion-java-benchmark-cli)
+* [ion-java-path-extraction](https://www.github.com/amzn/ion-java-path-extraction)
+* [ion-js](https://www.github.com/amzn/ion-js)
+* [ion-kotlin-builder](https://www.github.com/amzn/ion-kotlin-builder)
+* [ion-python](https://www.github.com/amzn/ion-python)
+* [ion-rust](https://www.github.com/amzn/ion-rust)
+* [ion-schema](https://www.github.com/amzn/ion-schema)
+* [ion-schema-kotlin](https://www.github.com/amzn/ion-schema-kotlin)
+* [ion-schema-rust](https://www.github.com/amzn/ion-schema-rust)


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

Add a README for the Amazon Ion [organization profile](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme). This is just a placeholder until we get things migrated.

The reason for adding this is so that we can start updating references such as [this one](https://github.com/popematt/ion-element-kotlin/commit/bdd6a765d8d59e0f4c3477f28db055946447400c#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L149) to point to the new organization.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
