### PR TITLE
Change http links to https

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 
 ## Licensing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,6 @@ we will investigate and subsequently address
 any potential vulnerabilities as quickly as possible.
 If you discover a potential security issue in this project,
 please notify AWS/Amazon Security via our
-[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+[vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/)
 or directly via email to [AWS Security](mailto:aws-security@amazon.com).
 Please do *not* create a public GitHub issue in this project.


### PR DESCRIPTION
### Issue #, if available:

amazon-ion/ion-java#484

### Description of changes:

Change `http` links to `https`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
